### PR TITLE
Fixes some issues with globals being set to none in __del__

### DIFF
--- a/tendo/singleton.py
+++ b/tendo/singleton.py
@@ -52,7 +52,7 @@ class SingleInstance:
         self.initialized = True
 
     def __del__(self):
-        import sys
+        import sys, os
         if not self.initialized:
             return
         try:
@@ -67,7 +67,10 @@ class SingleInstance:
                 if os.path.isfile(self.lockfile):
                     os.unlink(self.lockfile)
         except Exception, e:
-            logger.warning(e)
+            if logger:
+                logger.warning(e)
+            else:
+                print "Unloggable error: %s" % e
             sys.exit(-1)
 
 


### PR DESCRIPTION
At interpreter shutdown, the module's global variables are set to None before the module itself is released. See warning at http://docs.python.org/2/reference/datamodel.html#object.__del__ for more details.
