### PR TITLE
Fixed relative import on Python 3.3

### DIFF
--- a/tendo/__init__.py
+++ b/tendo/__init__.py
@@ -6,7 +6,7 @@ __author__ = "Sorin Sbarnea"
 __copyright__ = "Copyright 2010-2013, Sorin Sbarnea"
 __email__ = "sorin(dot)sbarnea(at)gmail.com"
 __status__ = "Production"
-from version import __version__, __date__
+from .version import __version__, __date__
 __date__ = "2013-03-22"
 
 __all__ = ['tee', 'colorer', 'unicode', 'execfile2', 'singleton', 'ansiterm']


### PR DESCRIPTION
Installation of tendo was failing on Python 3.3 because of the relative import of the `version` module in the `tendo` folder. Turns out, all you needed was the addition of a period (`.`) to fix it. Tested locally on Python 3.3 only.
