### PR TITLE
adding optional lockfile argument (with test)

### DIFF
--- a/tendo/singleton.py
+++ b/tendo/singleton.py
@@ -134,6 +134,11 @@ class testSingleton(unittest.TestCase):
         # instance running
         assert p.exitcode != 0, "%s != 0 (3rd execution)" % p.exitcode
 
+    def test_4(self):
+        lockfile = '/tmp/foo.lock'
+        me = SingleInstance(lockfile=lockfile)
+        assert me.lockfile == lockfile
+
 logger = logging.getLogger("tendo.singleton")
 logger.addHandler(logging.StreamHandler())
 

--- a/tendo/singleton.py
+++ b/tendo/singleton.py
@@ -28,14 +28,16 @@ class SingleInstance(object):
     Providing a flavor_id will augment the filename with the provided flavor_id, allowing you to create multiple singleton instances from the same file. This is particularly useful if you want specific functions to have their own singleton instances.
     """
 
-    def __init__(self, flavor_id=""):
+    def __init__(self, flavor_id="", lockfile=""):
         import sys
         self.initialized = False
-        basename = os.path.splitext(os.path.abspath(sys.argv[0]))[0].replace(
-            "/", "-").replace(":", "").replace("\\", "-") + '-%s' % flavor_id + '.lock'
-        # os.path.splitext(os.path.abspath(sys.modules['__main__'].__file__))[0].replace("/", "-").replace(":", "").replace("\\", "-") + '-%s' % flavor_id + '.lock'
-        self.lockfile = os.path.normpath(
-            tempfile.gettempdir() + '/' + basename)
+        if lockfile:
+            self.lockfile = lockfile
+        else:
+            basename = os.path.splitext(os.path.abspath(sys.argv[0]))[0].replace(
+                "/", "-").replace(":", "").replace("\\", "-") + '-%s' % flavor_id + '.lock'
+            self.lockfile = os.path.normpath(
+                tempfile.gettempdir() + '/' + basename)
 
         logger.debug("SingleInstance lockfile: " + self.lockfile)
         if sys.platform == 'win32':

--- a/tendo/singleton.py
+++ b/tendo/singleton.py
@@ -139,7 +139,7 @@ class testSingleton(unittest.TestCase):
         me = SingleInstance(lockfile=lockfile)
         assert me.lockfile == lockfile
 
-        
+
 logger = logging.getLogger("tendo.singleton")
 logger.addHandler(logging.StreamHandler())
 


### PR DESCRIPTION
We've got a need to standardize the lockfile path - different versions of our scripts have different paths, but we only want a single instance running across all versions. Thank you