### PR TITLE
Logger handler now being created only for unit tests.

### DIFF
--- a/tendo/singleton.py
+++ b/tendo/singleton.py
@@ -140,8 +140,8 @@ class testSingleton(unittest.TestCase):
 
 
 logger = logging.getLogger("tendo.singleton")
-logger.addHandler(logging.StreamHandler())
 
 if __name__ == "__main__":
+    logger.addHandler(logging.StreamHandler())
     logger.setLevel(logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
Prevents SingleInstance printing log messages twice on non-test environments.
Fixes 'SingleInstance prints log messages twice #39'